### PR TITLE
improve on swagger

### DIFF
--- a/mizql/evacuation/views.py
+++ b/mizql/evacuation/views.py
@@ -25,9 +25,10 @@ class ShelterViewSets(viewsets.ReadOnlyModelViewSet):
             ),
             coreapi.Field(
                 'distance',
-                required=True,
+                required=False,
                 location='query',
                 schema=coreschema.Integer(description='radius'),
+                description='Default is 1000'
             ),
         ]
     )
@@ -40,8 +41,10 @@ class ShelterViewSets(viewsets.ReadOnlyModelViewSet):
         if lat and lon:
             lat = float(lat)
             lon = float(lon)
-            return Shelter.objects.get_nearby_shelters_list(lat, lon, distance) \
-                .order_by('distance').all()
+            if self.action == 'list':
+                return Shelter.objects.get_nearby_shelters_list(lat, lon, distance) \
+                    .order_by('distance').all()
+            return Shelter.objects.with_distance(lat, lon).all()
         return Shelter.objects.all()
 
 


### PR DESCRIPTION
- distanceはよく考えたら必須じゃないのでrequired=Falseに
- 避難所の詳細の取得時に緯度経度でフィルタしてしまって取得できない不具合を修正
    - lat，lon付きでリクエストすると詳細取得時にも距離が取得できるように